### PR TITLE
hotfix: remove unpopulated columns

### DIFF
--- a/web/go.html
+++ b/web/go.html
@@ -71,16 +71,15 @@
                 <thead>
                   <tr>
                     <th> # </th>
-                    <th>Title </th>
-                    <th> Created </th>
-                    <th> Last run </th>
+                    <th> Title </th>
+                    <th> Last Run </th>
                     <th> Runs </th>
                     <th> Shared </th>
-                    <!--<th> Errors </th>
-                    <th> # Components </th>
-                    -->
                     <th> Schedule </th>
+                    <!--<th> Errors </th> -->
                     <th> Actions </th>
+                    <!-- <th> Schedule </th> --> 
+                    <!-- <th> Actions </th> -->
                   </tr>
                 </thead>
                 <tbody id='dir-body'> </tbody>


### PR DESCRIPTION
Two columns in the "Your Programs" table are unpopulated. The space left is filled by columns to the right, causing columns to shift left. This commit removes the last two columns from the table, and renames the columns to correspond properly to the data which they contain.

My guess is that the columns are supposed to contain information still, so this only acts as a temporary fix, as once the "CREATED" and "# COMPONENTS" columns are repopulated, the last two columns will need to be uncommented. For this reason, I left the columns commented rather than removing them all together. 

Incorporating the missing data back into its respective columns is a little above my pay grade. Hopefully this works for now. 